### PR TITLE
bail if class exist

### DIFF
--- a/Resources/stubs/CallbackFilterIterator.php
+++ b/Resources/stubs/CallbackFilterIterator.php
@@ -9,20 +9,22 @@
  * file that was distributed with this source code.
  */
 
-class CallbackFilterIterator extends FilterIterator
-{
-    private $iterator;
-    private $callback;
-
-    public function __construct(Iterator $iterator, $callback)
+if ( ! class_exists('CallbackFilterIterator')) :
+    class CallbackFilterIterator extends FilterIterator
     {
-        $this->iterator = $iterator;
-        $this->callback = $callback;
-        parent::__construct($iterator);
-    }
+        private $iterator;
+        private $callback;
 
-    public function accept()
-    {
-        return call_user_func($this->callback, $this->current(), $this->key(), $this->iterator);
+        public function __construct(Iterator $iterator, $callback)
+        {
+            $this->iterator = $iterator;
+            $this->callback = $callback;
+            parent::__construct($iterator);
+        }
+
+        public function accept()
+        {
+            return call_user_func($this->callback, $this->current(), $this->key(), $this->iterator);
+        }
     }
-}
+endif;


### PR DESCRIPTION
WordPress plugin svn repo has a pre-commit hook that run a check on php codes on various php version (think CI builds)

commit was failing due to existence of `CallbackFilterIterator` in php 5.4 already. add a class_exists check solved it.
