### PR TITLE
Add limit of before php 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3,<5.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Polyfill\\Php54\\": "" },


### PR DESCRIPTION
Add limit of before php 5.4 - so that the package does not install on systems that don't require it